### PR TITLE
Refactor cards to separate pages and fix mobile toggle

### DIFF
--- a/Monitor/monitor_app/templates/monitor_app/_collectors_list_card.html
+++ b/Monitor/monitor_app/templates/monitor_app/_collectors_list_card.html
@@ -2,6 +2,9 @@
     <div class="card-body">
         <div class="d-flex justify-content-between align-items-center mb-3 flex-wrap">
             <h5 class="card-title mb-0">Collectors List</h5>
+            <div class="w-50">
+                <input type="text" class="form-control" id="collectorsSearch" placeholder="Search collectors...">
+            </div>
             <a href="{% url 'monitor_app:add_collector' %}" class="btn btn-primary btn-sm mt-2 mt-md-0">
                 <i class="fas fa-plus me-1"></i>Add Collector
             </a>

--- a/Monitor/monitor_app/templates/monitor_app/_wifi_vendos_list_card.html
+++ b/Monitor/monitor_app/templates/monitor_app/_wifi_vendos_list_card.html
@@ -2,6 +2,9 @@
     <div class="card-body">
         <div class="d-flex justify-content-between align-items-center mb-3 flex-wrap">
             <h5 class="card-title mb-0">WiFi Vendos</h5>
+            <div class="w-50">
+                <input type="text" class="form-control" id="vendosSearch" placeholder="Search vendos...">
+            </div>
             <a href="{% url 'monitor_app:add_vendo' %}" class="btn btn-primary btn-sm mt-2 mt-md-0">
                 <i class="fas fa-plus me-1"></i>Add Vendo
             </a>

--- a/Monitor/monitor_app/templates/monitor_app/base.html
+++ b/Monitor/monitor_app/templates/monitor_app/base.html
@@ -191,43 +191,22 @@
             .mobile-circle-toggle {
                 display: flex !important;
             }
-            .mobile-circle-toggle.active {
-                background: linear-gradient(135deg, #dc3545, #c82333);
-                box-shadow: 0 6px 25px rgba(220, 53, 69, 0.5);
-                border-color: rgba(255, 255, 255, 0.4);
-            }
-            .mobile-circle-toggle.active:hover {
-                background: linear-gradient(135deg, #c82333, #a71e2a);
-                transform: scale(1.1);
-            }
             .sidebar {
                 position: fixed;
                 top: 0;
-                left: -280px; /* Hidden by default */
-                width: 280px;
+                left: 0;
                 height: 100%;
+                transform: translateX(-100%);
+                transition: transform 0.3s ease-in-out;
                 z-index: 1050;
-                transition: left 0.3s ease-in-out;
-                box-shadow: 0 0 20px rgba(0,0,0,0.2);
             }
             .sidebar.show {
-                left: 0;
-            }
-            .sidebar-header {
-                display: flex !important; /* Show header on mobile */
-            }
-            .sidebar-content {
-                max-height: calc(100vh - 80px);
-                overflow-y: auto;
+                transform: translateX(0);
             }
             .main-content {
                 margin-left: 0 !important;
                 width: 100%;
-                padding: 20px;
-                transition: margin-left 0.3s ease-in-out;
-            }
-            .main-content.sidebar-open {
-                margin-left: 280px;
+                padding-top: 80px; /* Space for the toggle button */
             }
             .mobile-backdrop.show {
                 display: block;
@@ -595,9 +574,8 @@
             // Toggle mobile sidebar
             function toggleMobileSidebar() {
                 sidebar.classList.toggle('show');
-                mobileCircleToggle.classList.toggle('active');
                 mobileBackdrop.classList.toggle('show');
-                mainContent.classList.toggle('sidebar-open');
+                mobileCircleToggle.classList.toggle('active');
 
                 if (sidebar.classList.contains('show')) {
                     document.body.style.overflow = 'hidden';

--- a/Monitor/monitor_app/templates/monitor_app/collectors_list.html
+++ b/Monitor/monitor_app/templates/monitor_app/collectors_list.html
@@ -1,0 +1,43 @@
+{% extends 'monitor_app/base.html' %}
+
+{% block title %}Collectors List - WiFi Vendo System{% endblock %}
+
+{% block content %}
+<div class="row">
+    <div class="col-12">
+        {% include 'monitor_app/_collectors_list_card.html' %}
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const searchInput = document.getElementById('collectorsSearch'); // Assuming you'll add an id to your search input
+    const table = document.querySelector('.table');
+    const rows = table.getElementsByTagName('tr');
+
+    if (searchInput && table && rows.length > 1) {
+        searchInput.addEventListener('keyup', function() {
+            const filter = searchInput.value.toLowerCase();
+
+            for (let i = 1; i < rows.length; i++) {
+                const cells = rows[i].getElementsByTagName('td');
+                if (cells.length > 0) {
+                    let rowText = '';
+                    for (let j = 0; j < cells.length; j++) {
+                        rowText += (cells[j].textContent || cells[j].innerText) + ' ';
+                    }
+
+                    if (rowText.toLowerCase().indexOf(filter) > -1) {
+                        rows[i].style.display = '';
+                    } else {
+                        rows[i].style.display = 'none';
+                    }
+                }
+            }
+        });
+    }
+});
+</script>
+{% endblock %}

--- a/Monitor/monitor_app/templates/monitor_app/dashboard.html
+++ b/Monitor/monitor_app/templates/monitor_app/dashboard.html
@@ -225,15 +225,7 @@
     {% endif %}
     <div class="row mt-2 align-items-stretch mobile-cards-row">
         {% if is_admin %}
-        <div class="col-md-4 col-12 mb-0 mb-md-3 h-100">
-            {% include 'monitor_app/_recent_sales_card.html' %}
-        </div>
-        <div class="col-md-4 col-12 mb-0 mb-md-3 h-100">
-            {% include 'monitor_app/_collectors_list_card.html' %}
-        </div>
-        <div class="col-md-4 col-12 mb-0 mb-md-0 h-100">
-            {% include 'monitor_app/_wifi_vendos_list_card.html' %}
-        </div>
+
         {% endif %}
     </div>
 {% endblock %}

--- a/Monitor/monitor_app/templates/monitor_app/recent_sales.html
+++ b/Monitor/monitor_app/templates/monitor_app/recent_sales.html
@@ -1,0 +1,36 @@
+{% extends 'monitor_app/base.html' %}
+
+{% block title %}Recent Sales - WiFi Vendo System{% endblock %}
+
+{% block content %}
+<div class="row">
+    <div class="col-12">
+        {% include 'monitor_app/_recent_sales_card.html' %}
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script type="text/javascript">
+    document.addEventListener('DOMContentLoaded', function() {
+        // Search functionality for sales/collections
+        const searchInput = document.getElementById('salesSearch');
+        const salesItems = document.querySelectorAll('.sales-item');
+
+        if (searchInput && salesItems.length > 0) {
+            searchInput.addEventListener('input', function() {
+                const searchTerm = this.value.toLowerCase();
+
+                salesItems.forEach(item => {
+                    const vendoName = item.querySelector('.vendo-name');
+                    if (vendoName && vendoName.textContent.toLowerCase().includes(searchTerm)) {
+                        item.style.display = '';
+                    } else {
+                        item.style.display = 'none';
+                    }
+                });
+            });
+        }
+    });
+</script>
+{% endblock %}

--- a/Monitor/monitor_app/templates/monitor_app/sidebar.html
+++ b/Monitor/monitor_app/templates/monitor_app/sidebar.html
@@ -58,12 +58,42 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link {% if request.resolver_match.url_name == 'add_vendo' %}active{% endif %}" 
+                        <a class="nav-link {% if request.resolver_match.url_name == 'add_vendo' %}active{% endif %}"
                            href="{% url 'monitor_app:add_vendo' %}">
                             <div class="nav-icon">
                                 <i class="fas fa-wifi"></i>
                             </div>
                             <span class="nav-text">Add Vendo</span>
+                            <div class="nav-indicator"></div>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link {% if request.resolver_match.url_name == 'recent_sales' %}active{% endif %}"
+                           href="{% url 'monitor_app:recent_sales' %}">
+                            <div class="nav-icon">
+                                <i class="fas fa-receipt"></i>
+                            </div>
+                            <span class="nav-text">Recent Sales</span>
+                            <div class="nav-indicator"></div>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link {% if request.resolver_match.url_name == 'collectors_list' %}active{% endif %}"
+                           href="{% url 'monitor_app:collectors_list' %}">
+                            <div class="nav-icon">
+                                <i class="fas fa-users"></i>
+                            </div>
+                            <span class="nav-text">Collectors List</span>
+                            <div class="nav-indicator"></div>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link {% if request.resolver_match.url_name == 'wifi_vendos_list' %}active{% endif %}"
+                           href="{% url 'monitor_app:wifi_vendos_list' %}">
+                            <div class="nav-icon">
+                                <i class="fas fa-list-alt"></i>
+                            </div>
+                            <span class="nav-text">WiFi Vendos List</span>
                             <div class="nav-indicator"></div>
                         </a>
                     </li>

--- a/Monitor/monitor_app/templates/monitor_app/wifi_vendos_list.html
+++ b/Monitor/monitor_app/templates/monitor_app/wifi_vendos_list.html
@@ -1,0 +1,43 @@
+{% extends 'monitor_app/base.html' %}
+
+{% block title %}WiFi Vendos List - WiFi Vendo System{% endblock %}
+
+{% block content %}
+<div class="row">
+    <div class="col-12">
+        {% include 'monitor_app/_wifi_vendos_list_card.html' %}
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const searchInput = document.getElementById('vendosSearch'); // Assuming you'll add an id to your search input
+    const table = document.querySelector('.table');
+    const rows = table.getElementsByTagName('tr');
+
+    if (searchInput && table && rows.length > 1) {
+        searchInput.addEventListener('keyup', function() {
+            const filter = searchInput.value.toLowerCase();
+
+            for (let i = 1; i < rows.length; i++) {
+                const cells = rows[i].getElementsByTagName('td');
+                if (cells.length > 0) {
+                    let rowText = '';
+                    for (let j = 0; j < cells.length; j++) {
+                        rowText += (cells[j].textContent || cells[j].innerText) + ' ';
+                    }
+
+                    if (rowText.toLowerCase().indexOf(filter) > -1) {
+                        rows[i].style.display = '';
+                    } else {
+                        rows[i].style.display = 'none';
+                    }
+                }
+            }
+        });
+    }
+});
+</script>
+{% endblock %}

--- a/Monitor/monitor_app/urls.py
+++ b/Monitor/monitor_app/urls.py
@@ -13,4 +13,7 @@ urlpatterns = [
     path('add-collector/', views.add_collector, name='add_collector'),
     path('add-vendo/', views.add_vendo, name='add_vendo'),
     path('reports/', views.reports, name='reports'),
+    path('recent-sales/', views.recent_sales_view, name='recent_sales'),
+    path('collectors/', views.collectors_list_view, name='collectors_list'),
+    path('wifi-vendos/', views.wifi_vendos_list_view, name='wifi_vendos_list'),
 ]

--- a/Monitor/monitor_app/views.py
+++ b/Monitor/monitor_app/views.py
@@ -421,3 +421,22 @@ def reports(request):
     }
     
     return render(request, 'monitor_app/reports.html', context)
+
+@login_required
+def recent_sales_view(request):
+    sales_records = SalesRecord.objects.all().order_by('-date')[:20] # Limit to 20 recent sales
+    return render(request, 'monitor_app/recent_sales.html', {'sales_records': sales_records})
+
+@login_required
+def collectors_list_view(request):
+    collectors = Collector.objects.all().annotate(
+        total_sales=Sum(Coalesce('salesrecord__amount', 0, output_field=DecimalField()))
+    )
+    return render(request, 'monitor_app/collectors_list.html', {'collectors': collectors})
+
+@login_required
+def wifi_vendos_list_view(request):
+    wifi_vendos = WifiVendo.objects.all().annotate(
+        total_sales=Sum(Coalesce('salesrecord__overall_profit', 0, output_field=DecimalField()))
+    )
+    return render(request, 'monitor_app/wifi_vendos_list.html', {'wifi_vendos': wifi_vendos})


### PR DESCRIPTION
This commit addresses several follow-up requests from the user:

- Refactored the "Recent Sales", "Collectors List", and "WiFi Vendos List" cards into their own separate pages with navigation links in the sidebar.
- Removed these cards from the main dashboard.
- Fixed the mobile navigation toggle to be more reliable and provide a better user experience.
- Verified that the year filter on the reports page correctly filters the "Monthly Breakdown" table.